### PR TITLE
fixing required constraint for root tree, and adding ability of default objects

### DIFF
--- a/fractal_input/input_handler.py
+++ b/fractal_input/input_handler.py
@@ -11,7 +11,8 @@ class InputHandler(object):
         self.output = None
         self.errors = []
 
-    def bind(self, input_data):
+    def bind(self, input_data, defaults={}):
+        self.root_node.defaults.update(defaults)
         self.define()
 
         self.input_data = input_data


### PR DESCRIPTION
Now you can do:

```py
class AdUpdateInput(InputHandler):
    def define(self):
        ad = self.add('ad', Ad)

        ad.add('title', 'string', {'required':False})
        ad.add('brand_url', 'string', {'required':False})
```

```py
ad = self.ad_repository.get_by_id(ad_id)

data = await self.get_request_json(request)

handler = self.get_input_handler('ad_update')
handler.bind(data, {'ad': ad})  # Here what happens is that you are decorating the ad object with a pre-existing one

if not handler.is_valid():
    return handler.get_error_as_string()

self.ad_service.update(ad)
``` 
       